### PR TITLE
add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,77 @@
+name: Build and Publish Python Package
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/publish.yml'
+  push:
+    branches: [ main ]
+    tags: '*'
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.1.0
+        with:
+          python-version: '3.11'
+
+      - name: Install build tools
+        run: |
+          pip install hatchling build twine check-wheel-contents uv
+
+      - name: Build package using Hatch
+        run: |
+          python -m build
+
+      - name: Check wheel contents
+        run: |
+          check-wheel-contents dist/*.whl
+
+      - name: Verify package can be installed
+        run: |
+          pip install dist/*.whl
+
+      - name: Test package import
+        run: |
+          python -c "import dataguard; print('Successfully imported dataguard')"
+
+      - name: Check package metadata
+        run: |
+          python -m twine check dist/*
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+  PyPI-upload:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish package to TestPyPI (on tag push)
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Publish package to PyPI (on release)
+        if: github.event_name == 'release' && github.event.action == 'published'
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Add publishing workflow for both testpypi and pypi: package name peh-dataguard. Should make installing a lot easier.